### PR TITLE
Rename `async-backtrace` to `taskdump`. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@
 #   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-# [0] https://github.com/google/async-backtrace/blob/main/.github/workflows/ci.yml
+# [0] https://github.com/google/taskdump/blob/main/.github/workflows/ci.yml
 
 name: CI
 
@@ -65,13 +65,13 @@ jobs:
     # sets the `CRATE_TOOLCHAIN` environment variable for future steps to use.
     #
     # Note that all metadata is stored in the `Cargo.toml` at
-    # the repository root. `async-backtrace-macros` is tested with the same versions,
+    # the repository root. `taskdump-attributes` is tested with the same versions,
     # and we have another CI job (see below) that makes sure that the
-    # `package.rust_version` key in async-backtrace-macros's `Cargo.toml` is the same
-    # as the one in async-backtrace's `Cargo.toml`. This key indicates the crate's
+    # `package.rust_version` key in taskdump-attributes's `Cargo.toml` is the same
+    # as the one in taskdump's `Cargo.toml`. This key indicates the crate's
     # MSRV, and if this check weren't present, it would be possible for
-    # async-backtrace-macros to be published with an earlier MSRV than the one we test
-    # for in CI - and thus potentially an MSRV that async-backtrace-macros isn't
+    # taskdump-attributes to be published with an earlier MSRV than the one we test
+    # for in CI - and thus potentially an MSRV that taskdump-attributes isn't
     # actually compatible with.
     - name: Set toolchain version
       run: |
@@ -82,7 +82,7 @@ jobs:
         }
         case ${{ matrix.toolchain }} in
           msrv)
-            CRATE_TOOLCHAIN="$(msrv async-backtrace)"
+            CRATE_TOOLCHAIN="$(msrv taskdump)"
             ;;
           stable)
             CRATE_TOOLCHAIN="stable"
@@ -196,7 +196,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.0.0
       - uses: extractions/setup-just@v1
-      # Make sure that the MSRV in async-backtrace's and async-backtrace-macros's
+      # Make sure that the MSRV in taskdump's and taskdump-attributes's
       # `Cargo.toml` files are the same.
       - name: Check MSRVs match
         run: just check-msrv

--- a/README.md
+++ b/README.md
@@ -1,50 +1,50 @@
 <!-- Do not edit README.md manually. Instead, edit the module comment of `backtrace/lib.rs`. -->
 
-# async-backtrace
+# taskdump
 
 Efficient, logical 'stack' traces of async functions.
 
 ## Usage
-To use, annotate your async functions with `#[async_backtrace::framed]`,
+To use, annotate your async functions with `#[taskdump::framed]`,
 like so:
 
 ```rust
 #[tokio::main]
 async fn main() {
     tokio::select! {
-        _ = tokio::spawn(async_backtrace::frame!(pending())) => {}
+        _ = tokio::spawn(taskdump::frame!(pending())) => {}
         _ = foo() => {}
     };
 }
 
-#[async_backtrace::framed]
+#[taskdump::framed]
 async fn pending() {
     std::future::pending::<()>().await
 }
 
-#[async_backtrace::framed]
+#[taskdump::framed]
 async fn foo() {
     bar().await;
 }
 
-#[async_backtrace::framed]
+#[taskdump::framed]
 async fn bar() {
     futures::join!(fiz(), buz());
 }
 
-#[async_backtrace::framed]
+#[taskdump::framed]
 async fn fiz() {
     tokio::task::yield_now().await;
 }
 
-#[async_backtrace::framed]
+#[taskdump::framed]
 async fn buz() {
     println!("{}", baz().await);
 }
 
-#[async_backtrace::framed]
+#[taskdump::framed]
 async fn baz() -> String {
-    async_backtrace::taskdump(true)
+    taskdump::taskdump(true)
 }
 ```
 
@@ -65,13 +65,13 @@ are marked with `#[framed]`.
 
 In other words, avoid doing this:
 ```rust
-tokio::spawn(async_backtrace::location!().frame(async {
+tokio::spawn(taskdump::location!().frame(async {
     foo().await;
     bar().await;
 })).await;
 
-#[async_backtrace::framed] async fn foo() {}
-#[async_backtrace::framed] async fn bar() {}
+#[taskdump::framed] async fn foo() {}
+#[taskdump::framed] async fn bar() {}
 ```
 ...and prefer doing this:
 ```rust
@@ -80,14 +80,14 @@ tokio::spawn(async {
     bar().await;
 }).await;
 
-#[async_backtrace::framed]
+#[taskdump::framed]
 async fn foo() {
     bar().await;
     baz().await;
 }
 
-#[async_backtrace::framed] async fn bar() {}
-#[async_backtrace::framed] async fn baz() {}
+#[taskdump::framed] async fn bar() {}
+#[taskdump::framed] async fn baz() {}
 ```
 
 ## Estimating Overhead

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ async fn buz() {
 
 #[taskdump::framed]
 async fn baz() -> String {
-    taskdump::taskdump(true)
+    taskdump::taskdump_tree(true)
 }
 ```
 

--- a/backtrace/Cargo.toml
+++ b/backtrace/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "async-backtrace"
+name = "taskdump"
 version = "0.1.0"
 edition = "2018"
 license = "MIT"
@@ -9,7 +9,7 @@ rust-version = "1.59"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-backtrace-macros = { version = "0.1", path = "../macros" }
+taskdump-attributes = { version = "0.1", path = "../macros" }
 dashmap = "5.4.0"
 futures = "0.3.21"
 once_cell = "1.0.0"

--- a/backtrace/benches/frame_overhead.rs
+++ b/backtrace/benches/frame_overhead.rs
@@ -74,7 +74,7 @@ fn bench_root_poll_first<M: Measurement<Value = Duration>>(c: &mut BenchmarkGrou
             }
             bench {
                 // initialize a `Frame`
-                let frame = async_backtrace::ඞ::Frame::new(async_backtrace::location!());
+                let frame = taskdump::ඞ::Frame::new(taskdump::location!());
                 tokio::pin!(frame);
                 // invoke `Frame::in_scope` once
                 let _ = black_box(frame.as_mut().in_scope(|| black_box(())));
@@ -109,7 +109,7 @@ fn bench_root_poll_rest<M: Measurement<Value = Duration>>(c: &mut BenchmarkGroup
             b;
             setup {
                 // initialize a `Frame`
-                let frame = async_backtrace::ඞ::Frame::new(async_backtrace::location!());
+                let frame = taskdump::ඞ::Frame::new(taskdump::location!());
                 tokio::pin!(frame);
                 // invoke `Frame::in_scope` once
                 let _ = black_box(frame.as_mut().in_scope(|| black_box(())));
@@ -135,13 +135,13 @@ fn bench_root_poll_rest<M: Measurement<Value = Duration>>(c: &mut BenchmarkGroup
 /// locking.
 fn bench_subframe_poll_first<M: Measurement<Value = Duration>>(c: &mut BenchmarkGroup<'_, M>) {
     c.bench_function("Frame::in_scope (subframe, first)", move |b| {
-        let root = async_backtrace::ඞ::Frame::new(async_backtrace::location!());
+        let root = taskdump::ඞ::Frame::new(taskdump::location!());
         tokio::pin!(root);
         root.in_scope(|| {
             // within the scope of a root `Frame`, benchmark:
             b.iter(|| {
                 // ...initializing a sub-`Frame`,
-                let frame = async_backtrace::ඞ::Frame::new(async_backtrace::location!());
+                let frame = taskdump::ඞ::Frame::new(taskdump::location!());
                 tokio::pin!(frame);
                 // ...and invoking `Frame::in_scope` once on it.
                 let _ = black_box(frame.as_mut().in_scope(|| black_box(())));
@@ -158,11 +158,11 @@ fn bench_subframe_poll_first<M: Measurement<Value = Duration>>(c: &mut Benchmark
 /// sub-`#[framed]` functions. It should be virtually free.
 fn bench_subframe_poll_rest<M: Measurement<Value = Duration>>(c: &mut BenchmarkGroup<'_, M>) {
     c.bench_function("Frame::in_scope (subframe, rest)", move |b| {
-        let root = async_backtrace::ඞ::Frame::new(async_backtrace::location!());
+        let root = taskdump::ඞ::Frame::new(taskdump::location!());
         tokio::pin!(root);
         root.in_scope(|| {
             // within the scope of a root `Frame`, initialize a subframe,
-            let frame = async_backtrace::ඞ::Frame::new(async_backtrace::location!());
+            let frame = taskdump::ඞ::Frame::new(taskdump::location!());
             tokio::pin!(frame);
             // invoke `Frame::in_scope` on it
             let _ = black_box(frame.as_mut().in_scope(|| black_box(())));

--- a/backtrace/examples/taskdump.rs
+++ b/backtrace/examples/taskdump.rs
@@ -14,32 +14,32 @@ async fn main() {
     };
 }
 
-#[async_backtrace::framed]
+#[taskdump::framed]
 async fn pending() {
     std::future::pending::<()>().await
 }
 
-#[async_backtrace::framed]
+#[taskdump::framed]
 async fn foo() {
     bar().await;
 }
 
-#[async_backtrace::framed]
+#[taskdump::framed]
 async fn bar() {
     futures::join!(fiz(), buz());
 }
 
-#[async_backtrace::framed]
+#[taskdump::framed]
 async fn fiz() {
     tokio::task::yield_now().await;
 }
 
-#[async_backtrace::framed]
+#[taskdump::framed]
 async fn buz() {
     println!("{}", baz().await);
 }
 
-#[async_backtrace::framed]
+#[taskdump::framed]
 async fn baz() -> String {
-    async_backtrace::taskdump(true)
+    taskdump::taskdump(true)
 }

--- a/backtrace/examples/taskdump.rs
+++ b/backtrace/examples/taskdump.rs
@@ -41,5 +41,5 @@ async fn buz() {
 
 #[taskdump::framed]
 async fn baz() -> String {
-    taskdump::taskdump(true)
+    taskdump::taskdump_tree(true)
 }

--- a/backtrace/src/lib.rs
+++ b/backtrace/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! #[taskdump::framed]
 //! async fn baz() -> String {
-//!     taskdump::taskdump(true)
+//!     taskdump::taskdump_tree(true)
 //! }
 //! ```
 //!
@@ -169,7 +169,7 @@ macro_rules! frame {
 /// top-level location of currently-running tasks and a note that they are
 /// "POLLING". Otherwise, this routine will wait for currently-running tasks to
 /// become idle.
-pub fn taskdump(wait_for_running_tasks: bool) -> String {
+pub fn taskdump_tree(wait_for_running_tasks: bool) -> String {
     tasks()
         .map(|task| task.dump_tree(wait_for_running_tasks))
         .collect()

--- a/backtrace/src/lib.rs
+++ b/backtrace/src/lib.rs
@@ -1,46 +1,46 @@
 //! Efficient, logical 'stack' traces of async functions.
 //!
 //! ## Usage
-//! To use, annotate your async functions with `#[async_backtrace::framed]`,
+//! To use, annotate your async functions with `#[taskdump::framed]`,
 //! like so:
 //!
 //! ```rust
 //! #[tokio::main]
 //! async fn main() {
 //!     tokio::select! {
-//!         _ = tokio::spawn(async_backtrace::frame!(pending())) => {}
+//!         _ = tokio::spawn(taskdump::frame!(pending())) => {}
 //!         _ = foo() => {}
 //!     };
 //! }
 //!
-//! #[async_backtrace::framed]
+//! #[taskdump::framed]
 //! async fn pending() {
 //!     std::future::pending::<()>().await
 //! }
 //!
-//! #[async_backtrace::framed]
+//! #[taskdump::framed]
 //! async fn foo() {
 //!     bar().await;
 //! }
 //!
-//! #[async_backtrace::framed]
+//! #[taskdump::framed]
 //! async fn bar() {
 //!     futures::join!(fiz(), buz());
 //! }
 //!
-//! #[async_backtrace::framed]
+//! #[taskdump::framed]
 //! async fn fiz() {
 //!     tokio::task::yield_now().await;
 //! }
 //!
-//! #[async_backtrace::framed]
+//! #[taskdump::framed]
 //! async fn buz() {
 //!     println!("{}", baz().await);
 //! }
 //!
-//! #[async_backtrace::framed]
+//! #[taskdump::framed]
 //! async fn baz() -> String {
-//!     async_backtrace::taskdump(true)
+//!     taskdump::taskdump(true)
 //! }
 //! ```
 //!
@@ -62,14 +62,14 @@
 //! In other words, avoid doing this:
 //! ```rust
 //! # #[tokio::main] async fn main() {
-//! tokio::spawn(async_backtrace::location!().frame(async {
+//! tokio::spawn(taskdump::location!().frame(async {
 //!     foo().await;
 //!     bar().await;
 //! })).await;
 //! # }
 //!
-//! #[async_backtrace::framed] async fn foo() {}
-//! #[async_backtrace::framed] async fn bar() {}
+//! #[taskdump::framed] async fn foo() {}
+//! #[taskdump::framed] async fn bar() {}
 //! ```
 //! ...and prefer doing this:
 //! ```rust
@@ -80,14 +80,14 @@
 //! }).await;
 //! # }
 //!
-//! #[async_backtrace::framed]
+//! #[taskdump::framed]
 //! async fn foo() {
 //!     bar().await;
 //!     baz().await;
 //! }
 //!
-//! #[async_backtrace::framed] async fn bar() {}
-//! #[async_backtrace::framed] async fn baz() {}
+//! #[taskdump::framed] async fn bar() {}
+//! #[taskdump::framed] async fn baz() {}
 //! ```
 //!
 //! ## Estimating Overhead
@@ -113,7 +113,7 @@ pub(crate) use tasks::tasks;
 /// ```
 /// # async fn bar() {}
 /// # async fn baz() {}
-/// #[async_backtrace::framed]
+/// #[taskdump::framed]
 /// async fn foo() {
 ///     bar().await;
 ///     baz().await;
@@ -124,13 +124,13 @@ pub(crate) use tasks::tasks;
 /// # async fn bar() {}
 /// # async fn baz() {}
 /// async fn foo() {
-///     async_backtrace::frame!(async move {
+///     taskdump::frame!(async move {
 ///         bar().await;
 ///         baz().await;
 ///     }).await;
 /// }
 /// ```
-pub use async_backtrace_macros::framed;
+pub use taskdump_attributes::framed;
 
 /// Include the annotated async expression in backtraces and taskdumps.
 ///
@@ -139,7 +139,7 @@ pub use async_backtrace_macros::framed;
 /// # #[tokio::main] async fn main() {
 /// # async fn foo() {}
 /// # async fn bar() {}
-/// tokio::spawn(async_backtrace::frame!(async {
+/// tokio::spawn(taskdump::frame!(async {
 ///     foo().await;
 ///     bar().await;
 /// })).await;
@@ -150,7 +150,7 @@ pub use async_backtrace_macros::framed;
 /// # #[tokio::main] async fn main() {
 /// # async fn foo() {}
 /// # async fn bar() {}
-/// tokio::spawn(async_backtrace::location!().frame(async {
+/// tokio::spawn(taskdump::location!().frame(async {
 ///     foo().await;
 ///     bar().await;
 /// })).await;
@@ -179,26 +179,26 @@ pub fn taskdump(wait_for_running_tasks: bool) -> String {
 ///
 /// ## Example
 /// ```
-/// use async_backtrace::{framed, backtrace, Location};
+/// use taskdump::{framed, backtrace, Location};
 ///
 /// #[tokio::main]
 /// async fn main() {
 ///     foo().await;
 /// }
 ///
-/// #[async_backtrace::framed]
+/// #[taskdump::framed]
 /// async fn foo() {
 ///     bar().await;
 /// }
 ///
-/// #[async_backtrace::framed]
+/// #[taskdump::framed]
 /// async fn bar() {
 ///     baz().await;
 /// }
 ///
-/// #[async_backtrace::framed]
+/// #[taskdump::framed]
 /// async fn baz() {
-///     assert_eq!(&async_backtrace::backtrace().unwrap().iter().map(|l| l.to_string()).collect::<Vec<_>>()[..], &[
+///     assert_eq!(&taskdump::backtrace().unwrap().iter().map(|l| l.to_string()).collect::<Vec<_>>()[..], &[
 ///         "rust_out::baz::{{closure}} at src/lib.rs:20:1",
 ///         "rust_out::bar::{{closure}} at src/lib.rs:15:1",
 ///         "rust_out::foo::{{closure}} at src/lib.rs:10:1",

--- a/backtrace/src/location.rs
+++ b/backtrace/src/location.rs
@@ -5,7 +5,7 @@ use futures::Future;
 /// Produces a [`Location`] when invoked in a function body.
 ///
 /// ```
-/// use async_backtrace::{location, Location};
+/// use taskdump::{location, Location};
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -71,7 +71,7 @@ impl Location {
     /// # async fn bar() {}
     /// # async fn baz() {}
     /// async fn foo() {
-    ///     async_backtrace::location!().frame(async move {
+    ///     taskdump::location!().frame(async move {
     ///         bar().await;
     ///         baz().await;
     ///     }).await

--- a/backtrace/tests/contention.rs
+++ b/backtrace/tests/contention.rs
@@ -1,17 +1,17 @@
-/// A test that async-backtrace is well-behaved under contention.
+/// A test that taskdump is well-behaved under contention.
 ///
 /// In this test, two threads are spawned:
 /// 1. Thread 1 executes a `framed` future, which requests a blocking taskdump
 /// three times in different ways (immediately, in a sub-frame, and upon drop).
 /// 2. Thread 2 requests a blocking taskdump.
 mod util;
-use async_backtrace::framed;
+use taskdump::framed;
 
 #[test]
 fn contention() {
     util::model(|| {
         let handle_a = util::thread::spawn(|| util::run(outer()));
-        let handle_b = util::thread::spawn(|| async_backtrace::taskdump(true));
+        let handle_b = util::thread::spawn(|| taskdump::taskdump(true));
         handle_a.join().unwrap();
         handle_b.join().unwrap();
     });

--- a/backtrace/tests/contention.rs
+++ b/backtrace/tests/contention.rs
@@ -11,7 +11,7 @@ use taskdump::framed;
 fn contention() {
     util::model(|| {
         let handle_a = util::thread::spawn(|| util::run(outer()));
-        let handle_b = util::thread::spawn(|| taskdump::taskdump(true));
+        let handle_b = util::thread::spawn(|| taskdump::taskdump_tree(true));
         handle_a.join().unwrap();
         handle_b.join().unwrap();
     });

--- a/backtrace/tests/deadlockless.rs
+++ b/backtrace/tests/deadlockless.rs
@@ -2,7 +2,7 @@
 /// from insided a framed future that spawns a scoped thread that requests the
 /// task dump.
 mod util;
-use async_backtrace::framed;
+use taskdump::framed;
 
 #[framed]
 fn deadlockless() {
@@ -11,7 +11,7 @@ fn deadlockless() {
 
 #[framed]
 async fn outer() {
-    let dump = std::thread::spawn(|| async_backtrace::taskdump(true))
+    let dump = std::thread::spawn(|| taskdump::taskdump(true))
         .join()
         .unwrap();
     pretty_assertions::assert_str_eq!(
@@ -25,7 +25,7 @@ async fn outer() {
 
 #[framed]
 async fn inner() {
-    let dump = util::thread::spawn(|| async_backtrace::taskdump(true))
+    let dump = util::thread::spawn(|| taskdump::taskdump(true))
         .join()
         .unwrap();
     pretty_assertions::assert_str_eq!(

--- a/backtrace/tests/deadlockless.rs
+++ b/backtrace/tests/deadlockless.rs
@@ -11,7 +11,7 @@ fn deadlockless() {
 
 #[framed]
 async fn outer() {
-    let dump = std::thread::spawn(|| taskdump::taskdump(true))
+    let dump = std::thread::spawn(|| taskdump::taskdump_tree(true))
         .join()
         .unwrap();
     pretty_assertions::assert_str_eq!(
@@ -25,7 +25,7 @@ async fn outer() {
 
 #[framed]
 async fn inner() {
-    let dump = util::thread::spawn(|| taskdump::taskdump(true))
+    let dump = util::thread::spawn(|| taskdump::taskdump_tree(true))
         .join()
         .unwrap();
     pretty_assertions::assert_str_eq!(

--- a/backtrace/tests/poll-in-drop.rs
+++ b/backtrace/tests/poll-in-drop.rs
@@ -1,7 +1,7 @@
-/// A test that async-backtrace is well-behaved when frames are await'ed inside
+/// A test that taskdump is well-behaved when frames are await'ed inside
 /// a drop guard.
 mod util;
-use async_backtrace::framed;
+use taskdump::framed;
 
 #[test]
 fn poll_in_drop() {
@@ -18,7 +18,7 @@ fn poll_in_drop() {
 
     #[framed]
     async fn inner() {
-        let dump = async_backtrace::taskdump(true);
+        let dump = taskdump::taskdump(true);
         pretty_assertions::assert_str_eq!(util::strip(dump), "\
 ╼ poll_in_drop::poll_in_drop::outer<poll_in_drop::util::Defer<poll_in_drop::poll_in_drop::{{closure}}::{{closure}}, ()>>::{{closure}} at backtrace/tests/poll-in-drop.rs:LINE:COL
   └╼ poll_in_drop::poll_in_drop::inner::{{closure}} at backtrace/tests/poll-in-drop.rs:LINE:COL");

--- a/backtrace/tests/poll-in-drop.rs
+++ b/backtrace/tests/poll-in-drop.rs
@@ -18,7 +18,7 @@ fn poll_in_drop() {
 
     #[framed]
     async fn inner() {
-        let dump = taskdump::taskdump(true);
+        let dump = taskdump::taskdump_tree(true);
         pretty_assertions::assert_str_eq!(util::strip(dump), "\
 ╼ poll_in_drop::poll_in_drop::outer<poll_in_drop::util::Defer<poll_in_drop::poll_in_drop::{{closure}}::{{closure}}, ()>>::{{closure}} at backtrace/tests/poll-in-drop.rs:LINE:COL
   └╼ poll_in_drop::poll_in_drop::inner::{{closure}} at backtrace/tests/poll-in-drop.rs:LINE:COL");

--- a/backtrace/tests/reentrant.rs
+++ b/backtrace/tests/reentrant.rs
@@ -10,7 +10,7 @@ fn reentrant() {
 
 #[framed]
 async fn outer() {
-    let dump = taskdump::taskdump(true);
+    let dump = taskdump::taskdump_tree(true);
     pretty_assertions::assert_str_eq!(
         util::strip(dump),
         "\
@@ -21,7 +21,7 @@ async fn outer() {
 
 #[framed]
 async fn inner() {
-    let dump = taskdump::taskdump(true);
+    let dump = taskdump::taskdump_tree(true);
     pretty_assertions::assert_str_eq!(
         util::strip(dump),
         "\

--- a/backtrace/tests/reentrant.rs
+++ b/backtrace/tests/reentrant.rs
@@ -1,7 +1,7 @@
 /// A test that a blocking threaddump does not deadlock a program when requested
 /// from within a `framed` task.
 mod util;
-use async_backtrace::framed;
+use taskdump::framed;
 
 #[test]
 fn reentrant() {
@@ -10,7 +10,7 @@ fn reentrant() {
 
 #[framed]
 async fn outer() {
-    let dump = async_backtrace::taskdump(true);
+    let dump = taskdump::taskdump(true);
     pretty_assertions::assert_str_eq!(
         util::strip(dump),
         "\
@@ -21,7 +21,7 @@ async fn outer() {
 
 #[framed]
 async fn inner() {
-    let dump = async_backtrace::taskdump(true);
+    let dump = taskdump::taskdump(true);
     pretty_assertions::assert_str_eq!(
         util::strip(dump),
         "\

--- a/justfile
+++ b/justfile
@@ -21,14 +21,14 @@ check-msrv:
         cargo metadata --format-version 1 | jq -r ".packages[] | select(.name == \"$1\").rust_version"
     }
 
-    ver_async_backtrace=$(msrv async-backtrace)
-    ver_async_backtrace_macros=$(msrv async-backtrace-macros)
+    ver_taskdump=$(msrv taskdump)
+    ver_taskdump_attributes=$(msrv taskdump-attributes)
 
-    if [[ "$ver_async_backtrace" == "$ver_async_backtrace_macros" ]]; then
-        echo "Same MSRV ($ver_async_backtrace) found in 'async-backtrace' and 'async-backtrace-macros'." | tee -a $GITHUB_STEP_SUMMARY
+    if [[ "$ver_taskdump" == "$ver_taskdump_attributes" ]]; then
+        echo "Same MSRV ($ver_taskdump) found in 'taskdump' and 'taskdump-attributes'." | tee -a $GITHUB_STEP_SUMMARY
         exit 0
     else
-        echo "Different MSRVs found in 'async-backtrace' ($ver_async_backtrace) and '$async-backtrace-macros' ($ver_async_backtrace_macros)." \
+        echo "Different MSRVs found in 'taskdump' ($ver_taskdump) and '$taskdump-attributes' ($ver_taskdump_attributes)." \
             | tee -a $GITHUB_STEP_SUMMARY >&2
         exit 1
     fi

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "async-backtrace-macros"
+name = "taskdump-attributes"
 version = "0.1.0"
 edition = "2018"
 license = "MIT"

--- a/macros/src/expand.rs
+++ b/macros/src/expand.rs
@@ -100,7 +100,7 @@ fn gen_block<B: ToTokens>(
     // which is `instrument`ed using `tracing-futures`. Otherwise, this will
     // enter the span and then perform the rest of the body.
     if async_context {
-        quote!(async_backtrace::frame!(async move { #block }).await)
+        quote!(taskdump::frame!(async move { #block }).await)
     } else {
         quote_spanned!(block.span() => #block)
     }


### PR DESCRIPTION
Dumping information about idle tasks is the primary purpose of this crate — the name should reflect that.

Additionally, the `taskdump` fn is renamed to `taskdump_tree`, in anticipation of `taskdump_json` being added soon.