### PR TITLE
backtrace: fix extra newlines at end of dumps

### DIFF
--- a/backtrace/Cargo.toml
+++ b/backtrace/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["asynchronous", "development-tools::debugging"]
 async-backtrace-attributes = { version = "0.2", path = "../attributes" }
 dashmap = "5.4.0"
 futures = "0.3.21"
+itertools = "0.10.5"
 once_cell = "1.0.0"
 pin-project-lite = "0.2"
 rustc-hash = "1.1.0"

--- a/backtrace/src/frame.rs
+++ b/backtrace/src/frame.rs
@@ -296,7 +296,7 @@ impl Frame {
             }
 
             // print all but the first three codepoints of current
-            writeln!(&mut f, "{}", {
+            write!(&mut f, "{}", {
                 let mut current = current.chars();
                 current.next().unwrap();
                 current.next().unwrap();
@@ -306,6 +306,7 @@ impl Frame {
 
             if subframes_locked {
                 frame.subframes().for_each(|frame| {
+                    writeln!(&mut f).unwrap();
                     let is_last = frame.next_frame().is_none();
                     fmt_helper(f, frame, is_last, &next, true).unwrap();
                 });

--- a/backtrace/src/lib.rs
+++ b/backtrace/src/lib.rs
@@ -164,9 +164,10 @@ macro_rules! frame {
 /// "POLLING". Otherwise, this routine will wait for currently-running tasks to
 /// become idle.
 pub fn taskdump_tree(wait_for_running_tasks: bool) -> String {
-    tasks()
-        .map(|task| task.dump_tree(wait_for_running_tasks))
-        .collect()
+    itertools::join(
+        tasks().map(|task| task.dump_tree(wait_for_running_tasks)),
+        "\n",
+    )
 }
 
 /// Produces a backtrace starting at the currently-active frame (if any).

--- a/backtrace/tests/util/mod.rs
+++ b/backtrace/tests/util/mod.rs
@@ -35,7 +35,7 @@ pub fn run<F: Future>(f: F) -> <F as Future>::Output {
 
 pub fn strip(str: impl AsRef<str>) -> String {
     let re = regex::Regex::new(r":\d+:\d+").unwrap();
-    re.replace_all(str.as_ref().trim(), ":LINE:COL").to_string()
+    re.replace_all(str.as_ref(), ":LINE:COL").to_string()
 }
 
 pub fn defer<F: FnOnce() -> R, R>(f: F) -> impl Drop {


### PR DESCRIPTION
Before:
```text
╼ taskdump::foo::{{closure}} at backtrace/examples/taskdump.rs:20:1
  └╼ taskdump::bar::{{closure}} at backtrace/examples/taskdump.rs:25:1
     ├╼ taskdump::buz::{{closure}} at backtrace/examples/taskdump.rs:35:1
     │  └╼ taskdump::baz::{{closure}} at backtrace/examples/taskdump.rs:40:1
     └╼ taskdump::fiz::{{closure}} at backtrace/examples/taskdump.rs:30:1
╼ taskdump::pending::{{closure}} at backtrace/examples/taskdump.rs:15:1

```
After:
```text
╼ taskdump::foo::{{closure}} at backtrace/examples/taskdump.rs:20:1
  └╼ taskdump::bar::{{closure}} at backtrace/examples/taskdump.rs:25:1
     ├╼ taskdump::buz::{{closure}} at backtrace/examples/taskdump.rs:35:1
     │  └╼ taskdump::baz::{{closure}} at backtrace/examples/taskdump.rs:40:1
     └╼ taskdump::fiz::{{closure}} at backtrace/examples/taskdump.rs:30:1
╼ taskdump::pending::{{closure}} at backtrace/examples/taskdump.rs:15:1
```