### PR TITLE
Ignore `clippy::empty_loop`

### DIFF
--- a/attributes/src/expand.rs
+++ b/attributes/src/expand.rs
@@ -55,7 +55,7 @@ pub(crate) fn gen_function<'a, B: ToTokens + 'a>(
     // unreachable, but does affect inference, so it needs to be written
     // exactly that way for it to do its magic.
     let fake_return_edge = quote_spanned! {return_span=>
-        #[allow(unreachable_code, clippy::diverging_sub_expression, clippy::let_unit_value)]
+        #[allow(unreachable_code, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::empty_loop)]
         if false {
             let __backtrace_attr_fake_return: #return_type = loop {};
             return __backtrace_attr_fake_return;


### PR DESCRIPTION
Using the `#[async_backtrace::framed]` macro was triggering this lint, unsure why this wasn't ignored as I believe the `empty_loop` is a default lint in clippy, but I noticed in CI only `check` is run, not clippy.