### PR TITLE
fix docs of `taskdump_tree()`

### DIFF
--- a/backtrace/src/lib.rs
+++ b/backtrace/src/lib.rs
@@ -159,7 +159,7 @@ macro_rules! frame {
 
 /// Produces a human-readable tree of task states.
 ///
-/// If `wait_for_running_tasks` is `true`, this routine will display only the
+/// If `wait_for_running_tasks` is `false`, this routine will display only the
 /// top-level location of currently-running tasks and a note that they are
 /// "POLLING". Otherwise, this routine will wait for currently-running tasks to
 /// become idle.

--- a/backtrace/src/tasks.rs
+++ b/backtrace/src/tasks.rs
@@ -35,7 +35,7 @@ impl Task {
     pub(crate) fn dump_tree(&self, wait_for_running_tasks: bool) -> String {
         use crate::sync::TryLockError;
 
-        // safety: we promsie to not inspect the subframes without first locking
+        // safety: we promise to not inspect the subframes without first locking
         let frame = unsafe { self.0.as_ref() };
 
         let current_task: Option<NonNull<Frame>> =


### PR DESCRIPTION
To wait for running tasks, the `wait_for_running_tasks` argument must be `true`.