### PR TITLE
fix output of `taskdump_tree(false)`

### DIFF
--- a/backtrace/src/frame.rs
+++ b/backtrace/src/frame.rs
@@ -313,7 +313,8 @@ impl Frame {
                     fmt_helper(f, frame, is_last, &next, true).unwrap();
                 });
             } else {
-                writeln!(f, "{prefix}└┈ [POLLING]")?;
+                writeln!(f)?;
+                write!(f, "{prefix}└┈ [POLLING]")?;
             }
 
             Ok(())


### PR DESCRIPTION
The newline is misplaced for `POLLING` tasks.

example old output (scroll right to see `POLLING`):
```
╼ util::measure::Measurement::spawn<core::future::from_generator::GenFuture<zettaobject::pool::Pool::initiate_flush_object_impl::{{closure}}>> at util/src/measure/mod.rs:154:22  └┈ [POLLING]

╼ util::measure::Measurement::spawn<core::future::from_generator::GenFuture<zettacache::zettacache::Inner::insert_all::{{closure}}::{{closure}}>> at util/src/measure/mod.rs:154:22
```
example new output:
```
╼ util::measure::Measurement::spawn<core::future::from_generator::GenFuture<zettacache::zettacache::Inner::insert_all::{{closure}}::{{closure}}>> at util/src/measure/mod.rs:154:22
  └┈ [POLLING]
╼ util::measure::Measurement::spawn<core::future::from_generator::GenFuture<zettaobject::pool::Pool::initiate_flush_object_impl::{{closure}}>> at util/src/measure/mod.rs:154:22
```