### PR TITLE
`taskdump_tree()`: consolidate adjacent identical frames

### DIFF
--- a/backtrace/examples/select.rs
+++ b/backtrace/examples/select.rs
@@ -10,6 +10,7 @@ async fn selecting() {
     tokio::select! {
         biased;
         _ = yielding() => {}
+        _ = yielding() => {}
         _ = ready() => {}
     };
 }

--- a/backtrace/src/frame.rs
+++ b/backtrace/src/frame.rs
@@ -307,9 +307,10 @@ impl Frame {
             })?;
 
             if subframes_locked {
-                for subframe in frame.subframes() {
+                let mut subframes = frame.subframes().peekable();
+                while let Some(subframe) = subframes.next() {
                     writeln!(f)?;
-                    let is_last = subframe.next_frame().is_none();
+                    let is_last = subframes.peek().is_none();
                     fmt_helper(f, subframe, is_last, &next, true)?;
                 }
             } else {
@@ -405,34 +406,6 @@ impl Frame {
         impl<'a> FusedIterator for Subframes<'a> {}
 
         Subframes::from_parent(self)
-    }
-
-    /// Produces this frame's previous (more-recently initialized) sibling (if
-    /// any).
-    ///
-    /// # Safety
-    /// The caller must ensure that the corresponding Kind::Root{mutex} is
-    /// locked.
-    pub unsafe fn prev_frame(&self) -> Option<&Frame> {
-        <Frame as linked_list::Link>::pointers(NonNull::from(self))
-            .as_ref()
-            .get_prev()
-            .as_ref()
-            .map(|f| f.as_ref())
-    }
-
-    /// Produces this frame's previous (less-recently initialized) sibling (if
-    /// any).
-    ///
-    /// # Safety
-    /// The caller must ensure that the corresponding Kind::Root{mutex} is
-    /// locked.
-    pub unsafe fn next_frame(&self) -> Option<&Frame> {
-        <Frame as linked_list::Link>::pointers(NonNull::from(self))
-            .as_ref()
-            .get_next()
-            .as_ref()
-            .map(|f| f.as_ref())
     }
 }
 

--- a/backtrace/src/frame.rs
+++ b/backtrace/src/frame.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 pin_project_lite::pin_project! {
-/// A [`Location`] in an intrusive, doubly-linked tree of [`Location`]s.
+/// A [`Frame`] in an intrusive, doubly-linked tree of [`Frame`]s.
 pub struct Frame {
     // The location associated with this frame.
     location: Location,

--- a/backtrace/tests/consolidate.rs
+++ b/backtrace/tests/consolidate.rs
@@ -1,5 +1,4 @@
-/// A test that async-backtrace is well-behaved when frames are await'ed inside
-/// a drop guard.
+/// A test that taskdump_tree() consolidates adjacent identical subframes.
 mod util;
 
 #[test]

--- a/backtrace/tests/consolidate.rs
+++ b/backtrace/tests/consolidate.rs
@@ -1,45 +1,42 @@
 /// A test that async-backtrace is well-behaved when frames are await'ed inside
 /// a drop guard.
 mod util;
-use std::{future::pending, sync::Arc};
-
-use async_backtrace::framed;
-use futures::future::join3;
-use itertools::Itertools;
-use tokio::sync::Barrier;
 
 #[test]
 fn consolidate() {
-    util::model(|| util::run(outer()));
+    util::model(|| util::run(selecting()));
 }
 
-#[framed]
-async fn outer() {
-    let barrier = Arc::new(Barrier::new(4));
-    let barrier2 = barrier.clone();
-    util::thread::spawn(|| util::run(lots(barrier2)));
-    barrier.wait().await;
+#[async_backtrace::framed]
+async fn selecting() {
+    tokio::select! {
+        biased;
+        _ = yielding_outer() => {}
+        _ = yielding_outer() => {}
+        _ = ready() => {}
+    };
+}
+
+#[async_backtrace::framed]
+async fn yielding_outer() {
+    yielding_inner().await;
+}
+
+#[async_backtrace::framed]
+async fn yielding_inner() {
+    tokio::task::yield_now().await;
+}
+
+#[async_backtrace::framed]
+async fn ready() {
     let dump = async_backtrace::taskdump_tree(true);
+
     pretty_assertions::assert_str_eq!(
-        itertools::join(util::strip(dump).lines().sorted(), "\n"),
-        r"  └╼ 3x consolidate::inner::{{closure}} at backtrace/tests/consolidate.rs:LINE:COL
-╼ consolidate::lots::{{closure}} at backtrace/tests/consolidate.rs:LINE:COL
-╼ consolidate::outer::{{closure}} at backtrace/tests/consolidate.rs:LINE:COL"
+        util::strip(dump),
+        "\
+╼ consolidate::selecting::{{closure}} at backtrace/tests/consolidate.rs:LINE:COL
+  ├╼ consolidate::ready::{{closure}} at backtrace/tests/consolidate.rs:LINE:COL
+  └╼ 2x consolidate::yielding_outer::{{closure}} at backtrace/tests/consolidate.rs:LINE:COL
+     └╼ consolidate::yielding_inner::{{closure}} at backtrace/tests/consolidate.rs:LINE:COL"
     );
-}
-
-#[framed]
-async fn lots(barrier: Arc<Barrier>) {
-    join3(
-        inner(barrier.clone()),
-        inner(barrier.clone()),
-        inner(barrier.clone()),
-    )
-    .await;
-}
-
-#[framed]
-async fn inner(barrier: Arc<Barrier>) {
-    barrier.wait().await;
-    pending::<()>().await;
 }

--- a/backtrace/tests/consolidate.rs
+++ b/backtrace/tests/consolidate.rs
@@ -1,0 +1,45 @@
+/// A test that async-backtrace is well-behaved when frames are await'ed inside
+/// a drop guard.
+mod util;
+use std::{future::pending, sync::Arc};
+
+use async_backtrace::framed;
+use futures::future::join3;
+use itertools::Itertools;
+use tokio::sync::Barrier;
+
+#[test]
+fn consolidate() {
+    util::model(|| util::run(outer()));
+}
+
+#[framed]
+async fn outer() {
+    let barrier = Arc::new(Barrier::new(4));
+    let barrier2 = barrier.clone();
+    util::thread::spawn(|| util::run(lots(barrier2)));
+    barrier.wait().await;
+    let dump = async_backtrace::taskdump_tree(true);
+    pretty_assertions::assert_str_eq!(
+        itertools::join(util::strip(dump).lines().sorted(), "\n"),
+        r"  └╼ 3x consolidate::inner::{{closure}} at backtrace/tests/consolidate.rs:LINE:COL
+╼ consolidate::lots::{{closure}} at backtrace/tests/consolidate.rs:LINE:COL
+╼ consolidate::outer::{{closure}} at backtrace/tests/consolidate.rs:LINE:COL"
+    );
+}
+
+#[framed]
+async fn lots(barrier: Arc<Barrier>) {
+    join3(
+        inner(barrier.clone()),
+        inner(barrier.clone()),
+        inner(barrier.clone()),
+    )
+    .await;
+}
+
+#[framed]
+async fn inner(barrier: Arc<Barrier>) {
+    barrier.wait().await;
+    pending::<()>().await;
+}


### PR DESCRIPTION
A task might be polling a lot of futures at the same time, e.g. using FuturesUnordered.  In this case, the output of `taskdump_tree()` can be really huge and repetitive, e.g.:

```
╼ util::measure::Measurement::spawn<core::future::from_generator::GenFuture<zettacache::zettacache::Inner::insert_all::{{closure}}::{{closure}}::{{closure}}>> at util/src/measure/mod.rs:151:22
  └╼ zettacache::zettacache::Inner::insert_all::{{closure}}::{{closure}} at zettacache/src/zettacache/mod.rs:1601:9
     ├╼ zettacache::zettacache::Inner::insert_impl::{{closure}} at zettacache/src/zettacache/mod.rs:1476:5
     │  └╼ zettacache::zettacache::Inner::insert_impl::{{closure}}::{{closure}} at zettacache/src/zettacache/mod.rs:1492:15
     │     └╼ zettacache::block_access::BlockAccess::write_raw::{{closure}} at zettacache/src/block_access.rs:723:5
     │        └╼ zettacache::block_access::Disk::write::{{closure}} at zettacache/src/block_access.rs:558:22
     ├╼ zettacache::zettacache::Inner::insert_impl::{{closure}} at zettacache/src/zettacache/mod.rs:1476:5
     │  └╼ zettacache::zettacache::Inner::insert_impl::{{closure}}::{{closure}} at zettacache/src/zettacache/mod.rs:1492:15
     │     └╼ zettacache::block_access::BlockAccess::write_raw::{{closure}} at zettacache/src/block_access.rs:723:5
     │        └╼ zettacache::block_access::Disk::write::{{closure}} at zettacache/src/block_access.rs:558:22
     ├╼ zettacache::zettacache::Inner::insert_impl::{{closure}} at zettacache/src/zettacache/mod.rs:1476:5
     │  └╼ zettacache::zettacache::Inner::insert_impl::{{closure}}::{{closure}} at zettacache/src/zettacache/mod.rs:1492:15
     │     └╼ zettacache::block_access::BlockAccess::write_raw::{{closure}} at zettacache/src/block_access.rs:723:5
     │        └╼ zettacache::block_access::Disk::write::{{closure}} at zettacache/src/block_access.rs:558:22
... repeats 200x
```

This PR makes `taskdump_tree()` consolidate adjacent identical subframes, printing a prefix like the `240x` below, to indicate that there are 240 instances of this subtree:
```
╼ util::measure::Measurement::spawn<core::future::from_generator::GenFuture<zettacache::zettacache::Inner::insert_all::{{closure}}::{{closure}}::{{closure}}>> at util/src/measure/mod.rs:154:22
  └╼ zettacache::zettacache::Inner::insert_all::{{closure}}::{{closure}} at zettacache/src/zettacache/mod.rs:1601:9
     └╼ 240x zettacache::zettacache::Inner::insert_impl::{{closure}} at zettacache/src/zettacache/mod.rs:1476:5
        └╼ zettacache::zettacache::Inner::insert_impl::{{closure}}::{{closure}} at zettacache/src/zettacache/mod.rs:1492:15
           └╼ zettacache::block_access::BlockAccess::write_raw::{{closure}} at zettacache/src/block_access.rs:723:5
              └╼ zettacache::block_access::Disk::write::{{closure}} at zettacache/src/block_access.rs:558:22
```

Note: I removed `prev_frame()` and `next_frame()`, which are now unused.  I thought that less `unsafe` code is better, but if we think they might be used in the future, I'd be fine with keeping them around.