### PR TITLE
make `tasks()`, `Task`, and related methods public

### DIFF
--- a/backtrace/src/lib.rs
+++ b/backtrace/src/lib.rs
@@ -99,7 +99,7 @@ pub(crate) mod tasks;
 pub(crate) use frame::Frame;
 pub(crate) use framed::Framed;
 pub use location::Location;
-pub(crate) use tasks::tasks;
+pub use tasks::{tasks, Task};
 
 /// Include the annotated async function in backtraces and taskdumps.
 ///
@@ -169,7 +169,7 @@ macro_rules! frame {
 /// non-async lock is held which may also be held by a Framed task.
 pub fn taskdump_tree(wait_for_running_tasks: bool) -> String {
     itertools::join(
-        tasks().map(|task| task.dump_tree(wait_for_running_tasks)),
+        tasks().map(|task| task.pretty_tree(wait_for_running_tasks)),
         "\n",
     )
 }

--- a/backtrace/src/tasks.rs
+++ b/backtrace/src/tasks.rs
@@ -45,11 +45,13 @@ impl Task {
 
     /// Pretty-prints this task as a tree.
     ///
-    /// If `block_until_idle` is `false`, the output will note that this task is
-    /// currently being polled, and will not descend into its sub-frames.
-    /// Otherwise, if `block_until_idle` is `true` this routine will block
-    /// until this task is no longer being polled, then recursively descend and
-    /// pretty-print its sub-frames.
+    /// If `block_until_idle` is `true`, this routine will block until the task
+    /// is no longer being polled.  In this case, the caller should not hold any
+    /// locks which might be held by the task, otherwise deadlock may occur.
+    ///
+    /// If `block_until_idle` is `false`, and the task is being polled, the
+    /// output will not include the sub-frames, instead simply note that the
+    /// task is being polled.
     pub fn pretty_tree(&self, block_until_idle: bool) -> String {
         use crate::sync::TryLockError;
 

--- a/backtrace/src/tasks.rs
+++ b/backtrace/src/tasks.rs
@@ -4,6 +4,7 @@ use once_cell::sync::Lazy;
 use rustc_hash::FxHasher;
 use std::{hash::BuildHasherDefault, ops::Deref, ptr::NonNull};
 
+/// A top-level [framed](crate::framed) future.
 #[derive(Hash, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct Task(NonNull<Frame>);
@@ -27,12 +28,29 @@ pub(crate) fn deregister(root_frame: &Frame) {
 }
 
 /// An iterator over tasks.
-pub(crate) fn tasks() -> impl Iterator<Item = impl Deref<Target = Task>> {
+///
+/// **NOTE:** The creation and destruction of some or all tasks will be blocked
+/// for as long as the return value of this function is live.
+pub fn tasks() -> impl Iterator<Item = impl Deref<Target = Task>> {
     TASK_SET.iter()
 }
 
 impl Task {
-    pub(crate) fn dump_tree(&self, wait_for_running_tasks: bool) -> String {
+    /// The location of this task.
+    pub fn location(&self) -> crate::Location {
+        // safety: we promise to not inspect the subframes without first locking
+        let frame = unsafe { self.0.as_ref() };
+        frame.location()
+    }
+
+    /// Pretty-prints this task as a tree.
+    ///
+    /// If `block_until_idle` is `false`, the output will note that this task is
+    /// currently being polled, and will not descend into its sub-frames.
+    /// Otherwise, if `block_until_idle` is `true` this routine will block
+    /// until this task is no longer being polled, then recursively descend and
+    /// pretty-print its sub-frames.
+    pub fn pretty_tree(&self, block_until_idle: bool) -> String {
         use crate::sync::TryLockError;
 
         // safety: we promise to not inspect the subframes without first locking
@@ -46,7 +64,7 @@ impl Task {
             // don't grab a lock if we're *in* the active task (it's already locked, then)
             .filter(|_| Some(self.0) != current_task)
             .map(|mutex| {
-                if wait_for_running_tasks {
+                if block_until_idle {
                     mutex.lock().map_err(TryLockError::from)
                 } else {
                     mutex.try_lock()


### PR DESCRIPTION
This will allow users to have finer control over task dumping.

See https://discord.com/channels/500028886025895936/1032353237166211092/1090303227288879154