### PR TITLE
attributes: suppress clippy warnings in generated code.

### DIFF
--- a/attributes/src/expand.rs
+++ b/attributes/src/expand.rs
@@ -55,7 +55,7 @@ pub(crate) fn gen_function<'a, B: ToTokens + 'a>(
     // unreachable, but does affect inference, so it needs to be written
     // exactly that way for it to do its magic.
     let fake_return_edge = quote_spanned! {return_span=>
-        #[allow(unreachable_code, clippy::diverging_sub_expression, clippy::let_unit_value, clippy::empty_loop)]
+        #[allow(unreachable_code, clippy::all)]
         if false {
             let __backtrace_attr_fake_return: #return_type = loop {};
             return __backtrace_attr_fake_return;


### PR DESCRIPTION
Fixes #25