### PR TITLE
Implement FusedFuture for framed futures

### DIFF
--- a/backtrace/src/framed.rs
+++ b/backtrace/src/framed.rs
@@ -1,6 +1,7 @@
 use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll};
+use futures::future::FusedFuture;
 use std::marker::PhantomPinned;
 
 use crate::frame::Frame;
@@ -47,5 +48,11 @@ where
         let frame = this.frame;
         let future = this.future;
         frame.in_scope(|| future.poll(cx))
+    }
+}
+
+impl<F: FusedFuture> FusedFuture for Framed<F> {
+    fn is_terminated(&self) -> bool {
+        self.future.is_terminated()
     }
 }

--- a/backtrace/src/location.rs
+++ b/backtrace/src/location.rs
@@ -77,7 +77,7 @@ impl Location {
     ///     }).await
     /// }
     /// ```
-    pub fn frame<F>(self, f: F) -> impl Future<Output = F::Output>
+    pub fn frame<F>(self, f: F) -> crate::Framed<F>
     where
         F: Future,
     {

--- a/backtrace/tests/fused.rs
+++ b/backtrace/tests/fused.rs
@@ -1,0 +1,26 @@
+use futures::{future::FusedFuture, FutureExt};
+
+/// A test that frame can propagate FusedFuture.
+mod util;
+
+#[test]
+fn consolidate() {
+    util::model(|| util::run(fused_future()));
+}
+
+#[async_backtrace::framed]
+fn fused_future() -> impl FusedFuture<Output = ()> {
+    async_backtrace::location!().frame(ready().fuse())
+}
+
+#[async_backtrace::framed]
+async fn ready() {
+    let dump = async_backtrace::taskdump_tree(true);
+
+    pretty_assertions::assert_str_eq!(
+        util::strip(dump),
+        "\
+╼ fused::fused_future at backtrace/tests/fused.rs:LINE:COL
+  └╼ fused::ready::{{closure}} at backtrace/tests/fused.rs:LINE:COL"
+    );
+}


### PR DESCRIPTION
this commit fixes #41

- Adds an implementation of FusedFuture for Frame<F> if F implements FusedFuture
- Location::framed() is changed to return the concrete Frame type so that call sites can infer whether or not FusedFuture is implemented by Frame<F>.
- A unit test is added